### PR TITLE
fix point submission on crystal 0.27

### DIFF
--- a/src/influxdb/point_value.cr
+++ b/src/influxdb/point_value.cr
@@ -30,7 +30,7 @@ module InfluxDB
     end
 
     private def parse_timestamp
-      @timestamp.not_nil!.epoch_ms
+      @timestamp.not_nil!.to_unix_ms
     end
 
     private def parse_hash(h, quote_escape = false)


### PR DESCRIPTION
crystal 0.27 has a breaking change for `Time` that causes a crash when trying to submit a datapoint.